### PR TITLE
Implement playhead position and current key event signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 LLM Omnipresent, for Youtube.
 
+## Features
+
+- Extracts captions from YouTube videos
+- Analyzes video content using Google's Gemini API
+- Identifies key events and timestamps in videos
+- Tracks current playhead position and active key event
+- Provides a UI for interacting with video analysis
+
+## Signals
+
+The application uses SolidJS signals to track state:
+
+- `currentVideoId`: The ID of the currently playing YouTube video
+- `currentCaptions`: The extracted captions for the current video
+- `currentPlayheadPosition`: The current playback position in seconds
+- `currentActiveEvent`: The currently active key event based on playhead position
+
 ## Development
 
 ``` sh

--- a/src/llmop/app.tsx
+++ b/src/llmop/app.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createEffect } from 'solid-js';
+import { createSignal, createEffect, createMemo } from 'solid-js';
 import { render } from 'solid-js/web';
 import { getPanel, showToast } from '@violentmonkey/ui';
 // Styles removed
@@ -9,7 +9,7 @@ import {
   currentVideoId,
   currentCaptions,
   currentPlayheadPosition,
-  currentActiveEvent,
+  currentEvents,
   setVideoEvents,
   delay,
 } from './youtube-watcher';
@@ -25,6 +25,63 @@ import {
 
 // Create a logger for this module
 const logger = createLogger('App');
+
+/**
+ * Create a derived signal that returns the current active event based on playhead position
+ * Returns null if no event is active or if not on a watch page
+ */
+const currentActiveEvent = createMemo(() => {
+  const playheadPosition = currentPlayheadPosition();
+  const events = currentEvents();
+
+  // If not on a watch page or no playhead position, return null
+  if (playheadPosition === null || events.length === 0) {
+    return null;
+  }
+
+  // Find the event whose timestamp is closest to but not after the current playhead position
+  // This assumes events are sorted by timestamp (which they should be)
+  let activeEvent: VideoEvent | null = null;
+  let closestTimeDiff = Number.MAX_SAFE_INTEGER;
+
+  for (const event of events) {
+    // Calculate how far the event is from the current position
+    const timeDiff = playheadPosition - event.timestamp;
+
+    // Only consider events that have already happened (timeDiff >= 0)
+    // and are closer than the current closest event
+    if (timeDiff >= 0 && timeDiff < closestTimeDiff) {
+      closestTimeDiff = timeDiff;
+      activeEvent = event;
+    }
+  }
+
+  return activeEvent;
+});
+
+/**
+ * Log a message every 30 seconds of playback
+ */
+createEffect(() => {
+  const position = currentPlayheadPosition();
+  const videoId = currentVideoId();
+
+  if (position !== null && videoId) {
+    // Log every 30 seconds
+    if (position > 0 && position % 30 < 1) {
+      logger.info(`Video playback at ${position} seconds`, { videoId });
+
+      // Also log the current active event if there is one
+      const activeEvent = currentActiveEvent();
+      if (activeEvent) {
+        logger.info(`Current active event: ${activeEvent.name}`, {
+          timestamp: activeEvent.timestamp,
+          description: activeEvent.description,
+        });
+      }
+    }
+  }
+});
 
 // Interface for the data that will be passed to the UI builder
 export interface UIData {

--- a/src/llmop/app.tsx
+++ b/src/llmop/app.tsx
@@ -5,7 +5,14 @@ import { getPanel, showToast } from '@violentmonkey/ui';
 // Import configuration
 import { getApiKey, getGeminiModel, getGeminiTemperature } from './config';
 // Import YouTube watcher
-import { currentVideoId, currentCaptions, delay } from './youtube-watcher';
+import {
+  currentVideoId,
+  currentCaptions,
+  currentPlayheadPosition,
+  currentActiveEvent,
+  setVideoEvents,
+  delay,
+} from './youtube-watcher';
 // Import debug utilities
 import { createLogger } from './debug';
 // Import Gemini client
@@ -36,6 +43,8 @@ export interface UIData {
   temperature: number;
   videoTitle: string;
   videoDescription: string;
+  currentPlayheadPosition: number | null;
+  currentActiveEvent: VideoEvent | null;
 }
 
 // Helper function to format seconds to MM:SS format
@@ -449,6 +458,8 @@ function YouTubeSummarizer() {
 
         // Update the UI with the results
         setEvents(result.events);
+        // Also update the shared events in youtube-watcher for the current active event signal
+        setVideoEvents(result.events);
         setSummary(result.summary); // Summary may contain timestamp links in the format [text](timestamp)
         setKeyPoints(result.keyPoints);
         setIsLoading(false);
@@ -479,6 +490,8 @@ function YouTubeSummarizer() {
           temperature: temperature(),
           videoTitle: videoTitle(),
           videoDescription: videoDescription(),
+          currentPlayheadPosition: currentPlayheadPosition(),
+          currentActiveEvent: currentActiveEvent(),
         };
 
         // Call the UI builder function
@@ -534,6 +547,8 @@ function YouTubeSummarizer() {
           temperature: temperature(),
           videoTitle: videoTitle(),
           videoDescription: videoDescription(),
+          currentPlayheadPosition: currentPlayheadPosition(),
+          currentActiveEvent: currentActiveEvent(),
         };
 
         buildUI(uiData);
@@ -627,6 +642,8 @@ function YouTubeSummarizer() {
           temperature: temperature(),
           videoTitle: videoTitle(),
           videoDescription: videoDescription(),
+          currentPlayheadPosition: currentPlayheadPosition(),
+          currentActiveEvent: currentActiveEvent(),
         };
 
         // Call the UI builder function

--- a/src/llmop/time-utils.ts
+++ b/src/llmop/time-utils.ts
@@ -1,0 +1,78 @@
+/**
+ * Time utility functions for LLMOP YouTube
+ * Contains functions for parsing and formatting time values
+ */
+
+import { createLogger } from './debug';
+
+// Create a logger for this module
+const logger = createLogger('TimeUtils');
+
+/**
+ * Parse a time string in the format "mm:ss" or "hh:mm:ss" to seconds
+ * @param timeString The time string to parse (e.g., "1:30" or "1:30:45")
+ * @returns The time in seconds, or null if parsing fails
+ */
+export function parseTimeString(timeString: string): number | null {
+  try {
+    if (!timeString) return null;
+
+    // Remove any whitespace
+    const trimmed = timeString.trim();
+
+    // Split by colon
+    const parts = trimmed.split(':');
+
+    if (parts.length === 2) {
+      // Format: mm:ss
+      const minutes = parseInt(parts[0], 10);
+      const seconds = parseInt(parts[1], 10);
+
+      if (isNaN(minutes) || isNaN(seconds)) {
+        logger.warn('Invalid time format', { timeString });
+        return null;
+      }
+
+      return minutes * 60 + seconds;
+    } else if (parts.length === 3) {
+      // Format: hh:mm:ss
+      const hours = parseInt(parts[0], 10);
+      const minutes = parseInt(parts[1], 10);
+      const seconds = parseInt(parts[2], 10);
+
+      if (isNaN(hours) || isNaN(minutes) || isNaN(seconds)) {
+        logger.warn('Invalid time format', { timeString });
+        return null;
+      }
+
+      return hours * 3600 + minutes * 60 + seconds;
+    }
+
+    logger.warn('Unsupported time format', { timeString });
+    return null;
+  } catch (error) {
+    logger.error('Error parsing time string', error);
+    return null;
+  }
+}
+
+/**
+ * Format seconds to a time string in the format "mm:ss"
+ * @param seconds The time in seconds
+ * @returns The formatted time string
+ */
+export function formatTimeString(seconds: number): string {
+  try {
+    if (isNaN(seconds) || seconds < 0) {
+      return '0:00';
+    }
+
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = Math.floor(seconds % 60);
+
+    return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
+  } catch (error) {
+    logger.error('Error formatting time string', error);
+    return '0:00';
+  }
+}

--- a/test/playhead-position.test.ts
+++ b/test/playhead-position.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Test script for the playhead position and current active event signals
+ *
+ * This is a manual test script that can be run in the browser console
+ * to verify that the signals are working correctly.
+ */
+
+import {
+  currentVideoId,
+  currentPlayheadPosition,
+  currentActiveEvent,
+  setVideoEvents,
+} from '../src/llmop/youtube-watcher';
+import { createEffect } from 'solid-js';
+import { VideoEvent } from '../src/llmop/gemini-client';
+
+// Create a test effect to log changes to the playhead position
+createEffect(() => {
+  const videoId = currentVideoId();
+  const position = currentPlayheadPosition();
+  const activeEvent = currentActiveEvent();
+
+  console.log('Playhead position update:', {
+    videoId,
+    position,
+    activeEvent: activeEvent
+      ? {
+          name: activeEvent.name,
+          timestamp: activeEvent.timestamp,
+        }
+      : null,
+  });
+});
+
+// Create some test events for testing the current active event signal
+const testEvents: VideoEvent[] = [
+  {
+    name: 'Introduction',
+    description: 'The video begins with an introduction',
+    timestamp: 0,
+  },
+  {
+    name: 'First point',
+    description: 'The speaker makes their first point',
+    timestamp: 30,
+  },
+  {
+    name: 'Second point',
+    description: 'The speaker makes their second point',
+    timestamp: 60,
+  },
+  {
+    name: 'Conclusion',
+    description: 'The video concludes with a summary',
+    timestamp: 90,
+  },
+];
+
+// Function to set the test events
+function setTestEvents() {
+  setVideoEvents(testEvents);
+  console.log('Set test events:', testEvents);
+}
+
+// Export functions for manual testing in the console
+window.testPlayheadPosition = {
+  setTestEvents,
+  getVideoId: () => currentVideoId(),
+  getPosition: () => currentPlayheadPosition(),
+  getActiveEvent: () => currentActiveEvent(),
+};
+
+console.log(
+  'Playhead position test script loaded. Use window.testPlayheadPosition to interact with the test.',
+);


### PR DESCRIPTION
This PR implements the feature described in issue #1.

## Changes

- Added a new `time-utils.ts` file with functions for parsing and formatting time strings
- Added signals in `youtube-watcher.ts` to track the current playhead position
- Added a polling mechanism that updates the playhead position every ~1 second
- Added a derived signal that determines the current active key event based on the playhead position
- Updated the `app.tsx` file to use the new signals and pass them to the UI builder
- Added a test script for manual testing of the new signals
- Updated the README.md with documentation for the new signals

## Testing

The implementation can be tested by:
1. Loading the userscript on a YouTube video page
2. Opening the browser console
3. Running the test script functions to verify the signals are updating correctly

Fixes #1