### PR TITLE
Fix changelog generation in release workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,36 @@
+changelog:
+  categories:
+    - title: 🚀 Features
+      labels:
+        - feature
+        - enhancement
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: 🧰 Maintenance
+      labels:
+        - chore
+        - refactor
+        - documentation
+    - title: 🔧 Performance Improvements
+      labels:
+        - performance
+        - optimization
+    - title: 🧪 Testing
+      labels:
+        - test
+    - title: 🔒 Security
+      labels:
+        - security
+    - title: 📦 Dependencies
+      labels:
+        - dependencies
+    - title: 🎨 UI/UX
+      labels:
+        - ui
+        - ux
+        - design
+    - title: 📝 Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,23 +63,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate changelog
-        id: changelog
-        run: |
-          # Get the latest tag
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-
-          if [ -z "$LATEST_TAG" ]; then
-            # If no tags exist, use all commits
-            echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
-            git log --pretty=format:"* %s (%h)" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-          else
-            # Otherwise, use commits since the latest tag
-            echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
-            git log ${LATEST_TAG}..HEAD --pretty=format:"* %s (%h)" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-          fi
+      # Using GitHub's automatically generated release notes instead of custom changelog generation
 
       - name: Create new release
         if: steps.check-release.outputs.exists == 'false'
@@ -87,9 +71,7 @@ jobs:
         with:
           name: v${{ steps.package-version.outputs.version }}
           tag_name: v${{ steps.package-version.outputs.version }}
-          body: |
-            ## Changelog
-            ${{ steps.changelog.outputs.CHANGELOG }}
+          generate_release_notes: true
           files: |
             dist/llmop.user.js
             dist/llmop.debug.user.js
@@ -104,9 +86,7 @@ jobs:
         with:
           name: v${{ steps.package-version.outputs.version }}
           tag_name: v${{ steps.package-version.outputs.version }}
-          body: |
-            ## Changelog
-            ${{ steps.changelog.outputs.CHANGELOG }}
+          generate_release_notes: true
           files: |
             dist/llmop.user.js
             dist/llmop.debug.user.js

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,34 +2,11 @@
 
 Thank you for your interest in contributing to LLMOP YouTube! This document provides guidelines for contributing to the project.
 
-## Pull Request Labels
-
-When creating a pull request, please add one or more of the following labels to help categorize your contribution. These labels are used to generate our release notes automatically.
-
-### Primary Labels
-
-| Label | Icon | Description |
-|-------|------|-------------|
-| `feature` | 🚀 | New features or significant enhancements |
-| `bug` | 🐛 | Bug fixes |
-| `fix` | 🐛 | Alternative label for bug fixes |
-| `chore` | 🧰 | Maintenance tasks, build changes, etc. |
-| `refactor` | 🧰 | Code refactoring without functionality changes |
-| `documentation` | 📚 | Documentation updates |
-| `performance` | 🔧 | Performance improvements |
-| `optimization` | 🔧 | Code optimizations |
-| `test` | 🧪 | Adding or updating tests |
-| `security` | 🔒 | Security-related changes |
-| `dependencies` | 📦 | Dependency updates |
-| `ui` | 🎨 | User interface changes |
-| `ux` | 🎨 | User experience improvements |
-| `design` | 🎨 | Visual design changes |
-
 ## Pull Request Process
 
 1. Fork the repository and create your branch from `main`.
 2. Make your changes and ensure they follow the project's coding standards.
-3. Add appropriate labels to your pull request based on the categories above.
+3. Add appropriate labels to your pull request for categorization in release notes.
 4. Update documentation as needed.
 5. Ensure all tests pass.
 6. Submit your pull request for review.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,29 +2,37 @@
 
 Thank you for your interest in contributing to LLMOP YouTube! This document provides guidelines for contributing to the project.
 
+## Pull Request Labels
+
+When creating a pull request, please add one or more of the following labels to help categorize your contribution. These labels are used to generate our release notes automatically.
+
+### Primary Labels
+
+| Label | Icon | Description |
+|-------|------|-------------|
+| `feature` | 🚀 | New features or significant enhancements |
+| `bug` | 🐛 | Bug fixes |
+| `fix` | 🐛 | Alternative label for bug fixes |
+| `chore` | 🧰 | Maintenance tasks, build changes, etc. |
+| `refactor` | 🧰 | Code refactoring without functionality changes |
+| `documentation` | 📚 | Documentation updates |
+| `performance` | 🔧 | Performance improvements |
+| `optimization` | 🔧 | Code optimizations |
+| `test` | 🧪 | Adding or updating tests |
+| `security` | 🔒 | Security-related changes |
+| `dependencies` | 📦 | Dependency updates |
+| `ui` | 🎨 | User interface changes |
+| `ux` | 🎨 | User experience improvements |
+| `design` | 🎨 | Visual design changes |
+
 ## Pull Request Process
 
 1. Fork the repository and create your branch from `main`.
 2. Make your changes and ensure they follow the project's coding standards.
-3. Add appropriate labels to your pull request for categorization in release notes.
+3. Add appropriate labels to your pull request based on the categories above.
 4. Update documentation as needed.
 5. Ensure all tests pass.
 6. Submit your pull request for review.
-
-## Commit Message Guidelines
-
-We follow conventional commit messages to make our commit history more readable and to automate the release process:
-
-- `feat:` - A new feature
-- `fix:` - A bug fix
-- `docs:` - Documentation changes
-- `style:` - Changes that do not affect the meaning of the code (formatting, etc.)
-- `refactor:` - Code changes that neither fix a bug nor add a feature
-- `perf:` - Performance improvements
-- `test:` - Adding or updating tests
-- `chore:` - Changes to the build process or auxiliary tools
-
-Example: `feat: add timestamp navigation in video player`
 
 ## Code of Conduct
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,56 @@
+# Contributing to LLMOP YouTube
+
+Thank you for your interest in contributing to LLMOP YouTube! This document provides guidelines for contributing to the project.
+
+## Pull Request Labels
+
+When creating a pull request, please add one or more of the following labels to help categorize your contribution. These labels are used to generate our release notes automatically.
+
+### Primary Labels
+
+| Label | Icon | Description |
+|-------|------|-------------|
+| `feature` | 🚀 | New features or significant enhancements |
+| `bug` | 🐛 | Bug fixes |
+| `fix` | 🐛 | Alternative label for bug fixes |
+| `chore` | 🧰 | Maintenance tasks, build changes, etc. |
+| `refactor` | 🧰 | Code refactoring without functionality changes |
+| `documentation` | 📚 | Documentation updates |
+| `performance` | 🔧 | Performance improvements |
+| `optimization` | 🔧 | Code optimizations |
+| `test` | 🧪 | Adding or updating tests |
+| `security` | 🔒 | Security-related changes |
+| `dependencies` | 📦 | Dependency updates |
+| `ui` | 🎨 | User interface changes |
+| `ux` | 🎨 | User experience improvements |
+| `design` | 🎨 | Visual design changes |
+
+## Pull Request Process
+
+1. Fork the repository and create your branch from `main`.
+2. Make your changes and ensure they follow the project's coding standards.
+3. Add appropriate labels to your pull request based on the categories above.
+4. Update documentation as needed.
+5. Ensure all tests pass.
+6. Submit your pull request for review.
+
+## Commit Message Guidelines
+
+We follow conventional commit messages to make our commit history more readable and to automate the release process:
+
+- `feat:` - A new feature
+- `fix:` - A bug fix
+- `docs:` - Documentation changes
+- `style:` - Changes that do not affect the meaning of the code (formatting, etc.)
+- `refactor:` - Code changes that neither fix a bug nor add a feature
+- `perf:` - Performance improvements
+- `test:` - Adding or updating tests
+- `chore:` - Changes to the build process or auxiliary tools
+
+Example: `feat: add timestamp navigation in video player`
+
+## Code of Conduct
+
+Please be respectful and considerate of others when contributing to this project. We aim to foster an inclusive and welcoming community.
+
+Thank you for your contributions!


### PR DESCRIPTION
This PR addresses issue #23 by implementing GitHub's automatically generated release notes.

## Changes:
- Add `.github/release.yml` for automatically generated release notes with categorized labels
- Create PR tagging strategy with custom labels for different types of changes
- Add CONTRIBUTORS.md to document label usage and contribution guidelines
- Update release workflow to use GitHub's automatic release notes generation

Fixes #23